### PR TITLE
Add Home Manager i3 migration

### DIFF
--- a/dotfiles/i3/config
+++ b/dotfiles/i3/config
@@ -202,11 +202,11 @@ exec --no-startup-id "feh --bg-fill BACKGROUND_IMAGE_PATH"
 exec --no-startup-id picom -b
 
 # print screen 
-bindsym Print exec --no-startup-id gscreenshot -sc
+bindsym Control+Shift+4 exec --no-startup-id gscreenshot -sc
 
 # set xrandr screen setting
 exec --no-startup-id XRANDR_SCREEN_SETTING_COMMAND
-I3_WORKSPACE_NUMBER_SETTINGS
+#I3_WORKSPACE_NUMBER_SETTINGS
 
 # turn on redshift
 exec --no-startup-id redshift 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777852249,
+        "narHash": "sha256-XdbGWnFlX4McOEG5NioVsp35Ic6XL/rXnp8as71cu6o=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "c909892de502b4de9e92838a503c09a9c8ebe4aa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "takabaya i3 dotfiles";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { nixpkgs, home-manager, ... }: {
+    homeConfigurations."takabaya@takabayap-H1-arch-i3" =
+      home-manager.lib.homeManagerConfiguration {
+        pkgs = import nixpkgs { system = "x86_64-linux"; };
+        extraSpecialArgs = { username = "takabaya"; };
+        modules = [
+          ./hosts/takabayap-H1-arch/default.nix
+          {
+            home.stateVersion = "24.11";
+            programs.home-manager.enable = true;
+          }
+        ];
+      };
+  };
+}

--- a/hosts/takabayap-H1-arch/default.nix
+++ b/hosts/takabayap-H1-arch/default.nix
@@ -1,0 +1,20 @@
+{ username, ... }:
+{
+  _module.args.hostConfig = {
+    xrandrCommand = "xrandr --output HDMI-0 --off --output DP-0 --mode 1920x1080 --pos 0x540 --rotate normal --output DP-1 --off --output DP-2 --mode 1920x1080 --pos 1920x120 --rotate right --output DP-3 --off --output DP-4 --mode 3840x2160 --pos 3000x0 --rotate normal --output DP-5 --off";
+    backgroundImage = "/usr/share/backgrounds/archlinux/sunset.jpg";
+    i3WorkspaceOutputs = ''
+      workspace 1 output DP-0
+      workspace 2 output DP-2
+      workspace 3 output DP-4
+      workspace 4 output DP-0
+      workspace 5 output DP-2
+      workspace 6 output DP-4
+    '';
+  };
+
+  home.username = username;
+  home.homeDirectory = "/home/${username}";
+
+  imports = [ ../../modules/linux/default.nix ];
+}

--- a/modules/linux/default.nix
+++ b/modules/linux/default.nix
@@ -1,0 +1,23 @@
+{ hostConfig, ... }:
+let
+  i3Config = builtins.replaceStrings
+    [
+      "XRANDR_SCREEN_SETTING_COMMAND"
+      "BACKGROUND_IMAGE_PATH"
+      "#I3_WORKSPACE_NUMBER_SETTINGS"
+    ]
+    [
+      hostConfig.xrandrCommand
+      hostConfig.backgroundImage
+      hostConfig.i3WorkspaceOutputs
+    ]
+    (builtins.readFile ../../dotfiles/i3/config);
+in
+{
+  xsession.enable = true;
+  xsession.windowManager.i3 = {
+    enable = true;
+    config = null;
+    extraConfig = i3Config;
+  };
+}


### PR DESCRIPTION
## Summary
- add a Home Manager/Nix flake setup with an i3-only activation target for gradual migration
- generate the existing i3 config through Home Manager with host-specific xrandr, wallpaper, and workspace output substitutions
- assign workspaces 1 and 4 to DP-0 since HDMI-0 is disabled

## Verification
- nix flake check
- nix build .#homeConfigurations."takabaya@takabayap-H1-arch-i3".activationPackage