### PR TITLE
Fix duplicate Alacritty window on alt-enter

### DIFF
--- a/modules/darwin/aerospace.nix
+++ b/modules/darwin/aerospace.nix
@@ -11,7 +11,7 @@
       on-focused-monitor-changed = [ "move-mouse monitor-lazy-center" ];
 
       mode.main.binding = {
-        alt-enter = "exec-and-forget /Applications/Alacritty.app/Contents/MacOS/alacritty";
+        alt-enter = "exec-and-forget ~/.nix-profile/bin/alacritty";
 
         alt-h = "focus --boundaries all-monitors-outer-frame left";
         alt-j = "focus --boundaries all-monitors-outer-frame down";


### PR DESCRIPTION
## Summary
- AeroSpace の `alt-enter` キーバインドで Alacritty が2つ開く問題を修正
- `/Applications/Alacritty.app/Contents/MacOS/alacritty` を `~/.nix-profile/bin/alacritty` に変更し、Nix管理のバイナリを使用するように統一
- 手動インストールされた `/Applications/AeroSpace.app` と `/Applications/Alacritty.app` が Nix 版と重複していたのが根本原因

## Root cause
手動インストール版の AeroSpace (`/Applications/AeroSpace.app`) と Nix 管理版が同時に起動していたため、両方が `alt-enter` を捕捉して各々 Alacritty を起動していた。

## Test plan
- [ ] `opt+enter` で Alacritty が1つだけ開くことを確認
- [ ] AeroSpace が1プロセスのみ起動していることを確認 (`ps aux | grep AeroSpace`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)