### PR TITLE
Add sketchybar with AeroSpace workspace integration

### DIFF
--- a/modules/darwin/aerospace.nix
+++ b/modules/darwin/aerospace.nix
@@ -8,6 +8,11 @@
       enable-normalization-flatten-containers = false;
       enable-normalization-opposite-orientation-for-nested-containers = false;
 
+      "exec-on-workspace-change" = [
+        "/bin/bash" "-c"
+        "sketchybar --trigger aerospace_workspace_change FOCUSED_WORKSPACE=$AEROSPACE_FOCUSED_WORKSPACE PREV_WORKSPACE=$AEROSPACE_PREV_WORKSPACE"
+      ];
+
       on-focused-monitor-changed = [ "move-mouse monitor-lazy-center" ];
 
       mode.main.binding = {

--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -3,6 +3,7 @@
   imports = [
     ./aerospace.nix
     ./alacritty.nix
+    ./sketchybar.nix
   ];
 
   services.jankyborders = {

--- a/modules/darwin/sketchybar.nix
+++ b/modules/darwin/sketchybar.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+{
+  programs.sketchybar = {
+    enable = true;
+    extraPackages = [ pkgs.jq ];
+    config = {
+      source = ./sketchybar;
+      recursive = true;
+    };
+  };
+}

--- a/modules/darwin/sketchybar/plugins/aerospace.sh
+++ b/modules/darwin/sketchybar/plugins/aerospace.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [ "$FOCUSED_WORKSPACE" != "" ]; then
+  for i in $(seq 1 10); do
+    if [ "$i" = "$FOCUSED_WORKSPACE" ]; then
+      sketchybar --set "space.$i" background.drawing=on icon.color=0xffcdd6f4
+    else
+      sketchybar --set "space.$i" background.drawing=off icon.color=0xff6c7086
+    fi
+  done
+fi

--- a/modules/darwin/sketchybar/plugins/battery.sh
+++ b/modules/darwin/sketchybar/plugins/battery.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+PERCENTAGE="$(pmset -g batt | grep -Eo "\d+%" | cut -d% -f1)"
+CHARGING="$(pmset -g batt | grep 'AC Power')"
+
+if [ "$CHARGING" != "" ]; then
+  ICON="󰂄"
+else
+  ICON="󰁹"
+fi
+
+sketchybar --set "$NAME" icon="$ICON" label="${PERCENTAGE}%"

--- a/modules/darwin/sketchybar/plugins/clock.sh
+++ b/modules/darwin/sketchybar/plugins/clock.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sketchybar --set "$NAME" label="$(date '+%H:%M')"

--- a/modules/darwin/sketchybar/plugins/front_app.sh
+++ b/modules/darwin/sketchybar/plugins/front_app.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sketchybar --set "$NAME" label="$INFO"

--- a/modules/darwin/sketchybar/sketchybarrc
+++ b/modules/darwin/sketchybar/sketchybarrc
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+PLUGIN_DIR="$CONFIG_DIR/plugins"
+
+# --- Colors (Catppuccin Mocha) ---
+BAR_COLOR="0xff1e1e2e"
+ITEM_BG_COLOR="0xff313244"
+ACCENT_COLOR="0xff89b4fa"
+FG_COLOR="0xffcdd6f4"
+FG_INACTIVE="0xff6c7086"
+
+# --- Bar ---
+sketchybar --bar height=32 \
+                position=top \
+                sticky=on \
+                padding_left=8 \
+                padding_right=8 \
+                color="$BAR_COLOR"
+
+# --- Defaults ---
+sketchybar --default icon.font="Hack Nerd Font:Bold:14.0" \
+                     icon.color="$FG_COLOR" \
+                     label.font="Hack Nerd Font:Regular:13.0" \
+                     label.color="$FG_COLOR" \
+                     background.color="$ITEM_BG_COLOR" \
+                     background.corner_radius=5 \
+                     background.height=24 \
+                     padding_left=5 \
+                     padding_right=5 \
+                     label.padding_left=4 \
+                     label.padding_right=4 \
+                     icon.padding_left=4 \
+                     icon.padding_right=4
+
+# --- Aerospace Workspace Change Event ---
+sketchybar --add event aerospace_workspace_change
+
+# --- Workspaces (left) ---
+for i in $(seq 1 10); do
+  sketchybar --add item "space.$i" left \
+             --subscribe "space.$i" aerospace_workspace_change \
+             --set "space.$i" \
+               icon="$i" \
+               icon.color="$FG_INACTIVE" \
+               label.drawing=off \
+               script="$PLUGIN_DIR/aerospace.sh" \
+               click_script="aerospace workspace $i" \
+               background.drawing=off
+done
+
+# Highlight current workspace on launch
+CURRENT="$(aerospace list-workspaces --focused 2>/dev/null || echo 1)"
+sketchybar --set "space.$CURRENT" background.drawing=on icon.color="$FG_COLOR"
+
+# --- Front App (left) ---
+sketchybar --add item front_app left \
+           --subscribe front_app front_app_switched \
+           --set front_app \
+             icon.drawing=off \
+             script="$PLUGIN_DIR/front_app.sh"
+
+# --- Clock (right) ---
+sketchybar --add item clock right \
+           --set clock \
+             icon="󰥔" \
+             update_freq=10 \
+             script="$PLUGIN_DIR/clock.sh"
+
+# --- Battery (right) ---
+sketchybar --add item battery right \
+           --set battery \
+             update_freq=120 \
+             script="$PLUGIN_DIR/battery.sh"
+
+# --- Init ---
+sketchybar --update


### PR DESCRIPTION
## Summary

- sketchybar を Nix home-manager モジュール (`programs.sketchybar`) で管理する構成を追加
- AeroSpace のワークスペース切り替え時に sketchybar へイベント通知する連携を追加
- Catppuccin Mocha 配色、ワークスペースインジケーター・フロントアプリ・時計・バッテリー表示

## Changes

- `modules/darwin/sketchybar.nix`: home-manager モジュール定義（ディレクトリソース方式）
- `modules/darwin/sketchybar/sketchybarrc`: メイン設定スクリプト
- `modules/darwin/sketchybar/plugins/`: プラグインスクリプト群（aerospace, front_app, clock, battery）
- `modules/darwin/aerospace.nix`: `exec-on-workspace-change` フック追加
- `modules/darwin/default.nix`: import 追加

## Notes

- 初回適用後、macOS System Settings > Privacy & Security > Accessibility で sketchybar に権限付与が必要
- Hack Nerd Font がインストール済みであること前提