### PR TITLE
Add common shell tooling paths

### DIFF
--- a/dotfiles/bashrc/.bashrc
+++ b/dotfiles/bashrc/.bashrc
@@ -17,4 +17,13 @@ export CHROME_EXECUTABLE=/usr/bin/vivaldi-stable
 PATH=$ANDROID_HOME/emulator:$PATH
 PS1='[\u@\h \W]\$ '
 complete -cf sudo
+
+export PATH="$HOME/.local/bin:$PATH"
+[ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+
+# Added by LM Studio CLI tool (lms)
+export PATH="$PATH:/Users/katsumi.kobayashi/.lmstudio/bin"
+
+[ -f "$HOME/.local/bin/env" ] && . "$HOME/.local/bin/env"
+
 fish

--- a/dotfiles/fish/config.fish
+++ b/dotfiles/fish/config.fish
@@ -1,10 +1,9 @@
-if status is-interactive
-    # Commands to run in interactive sessions can go here
-    set -g fish_greeting
-end
-
+set -g fish_greeting
 alias vim='nvim'
 alias vi='nvim'
 alias cat='bat --paging never'
 alias gf='git push -f'
 alias cdg='cd $(git rev-parse --show-toplevel)'
+
+# Added by LM Studio CLI tool (lms)
+set -gx PATH $PATH /Users/katsumi.kobayashi/.lmstudio/bin

--- a/modules/common/default.nix
+++ b/modules/common/default.nix
@@ -1,8 +1,12 @@
-{ ... }:
+{ pkgs, ... }:
 {
   imports = [
     ./neovim.nix
     ./alacritty.nix
+  ];
+
+  home.packages = [
+    pkgs.fastfetch
   ];
 }
 

--- a/modules/common/neovim.nix
+++ b/modules/common/neovim.nix
@@ -20,7 +20,6 @@
       softtabstop = 4;
       termguicolors = true;
       mouse = "a";
-      directory = "$HOME/.nvim/tmp//";
     };
 
     # --------------------------------------------------------------------------
@@ -104,6 +103,7 @@
       keymaps = {
         lspBuf = {
           "gd" = "definition";
+          "gi" = "implementation";
           "K" = "hover";
           "<F2>" = "rename";
           "<leader>ca" = "code_action";
@@ -121,6 +121,12 @@
     };
 
     highlightOverride = {
+      Normal = { bg = "none"; };
+      NormalNC = { bg = "none"; };
+      NormalFloat = { bg = "none"; };
+      SignColumn = { bg = "none"; };
+      LineNr = { bg = "none"; };
+      FoldColumn = { bg = "none"; };
       DiagnosticUnderlineError = { underline = true; sp = "#ff0000"; };
       DiagnosticUnderlineWarn = { underline = true; sp = "#ffcc00"; };
       DiagnosticUnderlineInfo = { underline = true; sp = "#00bfff"; };


### PR DESCRIPTION
## Summary
- add fastfetch to common Home Manager packages
- add local, cargo, and LM Studio paths for bash and fish
- keep bash env loading before handing off to fish

## Test
- nix flake check --no-build --all-systems