### PR TITLE
Add SketchyBar system widgets

### DIFF
--- a/modules/darwin/aerospace.nix
+++ b/modules/darwin/aerospace.nix
@@ -8,9 +8,9 @@ let
 
     gaps = {
       outer.top = [
-        { monitor = { "BenQ GW2480.*1" = 32; }; }
-        { monitor = { "BenQ GW2480.*2" = 32; }; }
-        { monitor = { "LG HDR 4K" = 32; }; }
+        { monitor = { "BenQ GW2480.*1" = 38; }; }
+        { monitor = { "BenQ GW2480.*2" = 38; }; }
+        { monitor = { "LG HDR 4K" = 38; }; }
         0
       ];
     };

--- a/modules/darwin/sketchybar.nix
+++ b/modules/darwin/sketchybar.nix
@@ -1,11 +1,7 @@
-{ pkgs, ... }:
+{ ... }:
 {
-  programs.sketchybar = {
-    enable = true;
-    extraPackages = [ pkgs.jq ];
-    config = {
-      source = ./sketchybar;
-      recursive = true;
-    };
+  xdg.configFile."sketchybar" = {
+    source = ./sketchybar;
+    recursive = true;
   };
 }

--- a/modules/darwin/sketchybar/plugins/battery.sh
+++ b/modules/darwin/sketchybar/plugins/battery.sh
@@ -1,12 +1,27 @@
 #!/usr/bin/env bash
 
-PERCENTAGE="$(pmset -g batt | grep -Eo "\d+%" | cut -d% -f1)"
-CHARGING="$(pmset -g batt | grep 'AC Power')"
+PMSET_OUTPUT=$(pmset -g batt)
+PERCENTAGE=$(echo "$PMSET_OUTPUT" | grep -Eo "[0-9]+%" | cut -d% -f1)
+CHARGING=$(echo "$PMSET_OUTPUT" | grep 'AC Power')
 
-if [ "$CHARGING" != "" ]; then
+if [ -n "$CHARGING" ]; then
   ICON="󰂄"
+  COLOR="0xffa6e3a1"
+elif [ "$PERCENTAGE" -ge 80 ]; then
+  ICON="󰂁"
+  COLOR="0xffa6e3a1"
+elif [ "$PERCENTAGE" -ge 60 ]; then
+  ICON="󰁿"
+  COLOR="0xffa6e3a1"
+elif [ "$PERCENTAGE" -ge 40 ]; then
+  ICON="󰁽"
+  COLOR="0xfff9e2af"
+elif [ "$PERCENTAGE" -ge 20 ]; then
+  ICON="󰁻"
+  COLOR="0xfff9e2af"
 else
-  ICON="󰁹"
+  ICON="󰂎"
+  COLOR="0xfff38ba8"
 fi
 
-sketchybar --set "$NAME" icon="$ICON" label="${PERCENTAGE}%"
+sketchybar --set "$NAME" icon="$ICON" icon.color="$COLOR" label="${PERCENTAGE}%"

--- a/modules/darwin/sketchybar/plugins/clock.sh
+++ b/modules/darwin/sketchybar/plugins/clock.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-sketchybar --set "$NAME" label="$(date '+%H:%M')"

--- a/modules/darwin/sketchybar/plugins/cpu.sh
+++ b/modules/darwin/sketchybar/plugins/cpu.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+CPU=$(top -l 2 -n 0 | awk '/CPU usage/ {sum += $3 + $5; n++} END {if(n>0) printf "%.0f", sum/n; else print "0"}')
+sketchybar --set "$NAME" label="CPU ${CPU}%" --push "$NAME" "$(echo "$CPU" | awk '{printf "%.2f", $1/100}')"

--- a/modules/darwin/sketchybar/plugins/front_app.sh
+++ b/modules/darwin/sketchybar/plugins/front_app.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-sketchybar --set "$NAME" label="$INFO"

--- a/modules/darwin/sketchybar/plugins/memory.sh
+++ b/modules/darwin/sketchybar/plugins/memory.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+PAGE_SIZE=$(sysctl -n hw.pagesize)
+TOTAL_MEM=$(sysctl -n hw.memsize)
+
+VMSTAT=$(vm_stat)
+ACTIVE=$(echo "$VMSTAT" | awk '/Pages active/ {gsub(/\./,"",$3); print $3}')
+WIRED=$(echo "$VMSTAT" | awk '/Pages wired/ {gsub(/\./,"",$4); print $4}')
+COMPRESSED=$(echo "$VMSTAT" | awk '/Pages occupied by compressor/ {gsub(/\./,"",$5); print $5}')
+
+USED_BYTES=$(( (ACTIVE + WIRED + COMPRESSED) * PAGE_SIZE ))
+USED_GB=$(echo "$USED_BYTES" | awk "{printf \"%.0f\", \$1/1024/1024/1024}")
+#TOTAL_GB=$(echo "$TOTAL_MEM" | awk "{printf \"%.0f\", \$1/1024/1024/1024}")
+RATIO=$(echo "$USED_BYTES $TOTAL_MEM" | awk '{printf "%.2f", $1/$2}')
+
+#sketchybar --set "$NAME" label="MEM ${USED_GB}/${TOTAL_GB}GB" --push "$NAME" "$RATIO"
+sketchybar --set "$NAME" label="MEM ${USED_GB}GB" --push "$NAME" "$RATIO"

--- a/modules/darwin/sketchybar/plugins/time.sh
+++ b/modules/darwin/sketchybar/plugins/time.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sketchybar --set "$NAME" label="$(date '+%m/%d(%a) %H:%M')"

--- a/modules/darwin/sketchybar/plugins/volume.sh
+++ b/modules/darwin/sketchybar/plugins/volume.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+if [ "$SENDER" = "volume_change" ]; then
+  VOLUME="$INFO"
+else
+  VOLUME="$(osascript -e 'output volume of (get volume settings)' 2>/dev/null)"
+fi
+
+if [ "$VOLUME" = "missing value" ] || [ -z "$VOLUME" ]; then
+  VOLUME="--"
+fi
+
+DEVICE="$(system_profiler SPAudioDataType 2>/dev/null | awk '/^        [^ ].*:$/{device=$0} /Default Output Device: Yes/{print device; exit}' | sed 's/^[[:space:]]*//' | sed 's/:$//')"
+
+if [ "$VOLUME" = "--" ]; then
+  ICON="󰕾"
+elif [ "$VOLUME" -eq 0 ] 2>/dev/null; then
+  ICON="󰝟"
+elif [ "$VOLUME" -lt 30 ]; then
+  ICON="󰕿"
+elif [ "$VOLUME" -lt 60 ]; then
+  ICON="󰖀"
+else
+  ICON="󰕾"
+fi
+
+sketchybar --set "$NAME" icon="$ICON" label="${VOLUME}% ${DEVICE}"

--- a/modules/darwin/sketchybar/sketchybarrc
+++ b/modules/darwin/sketchybar/sketchybarrc
@@ -2,15 +2,16 @@
 
 PLUGIN_DIR="$CONFIG_DIR/plugins"
 
-# --- Colors (Catppuccin Mocha) ---
-BAR_COLOR="0xff1e1e2e"
-ITEM_BG_COLOR="0xff313244"
+# --- Colors (Catppuccin Mocha, 80% opacity) ---
+BAR_COLOR="0xcc1e1e2e"
+BRACKET_BG="0xcc313244"
 ACCENT_COLOR="0xff89b4fa"
 FG_COLOR="0xffcdd6f4"
 FG_INACTIVE="0xff6c7086"
+GREEN="0xffa6e3a1"
 
 # --- Bar ---
-sketchybar --bar height=32 \
+sketchybar --bar height=38 \
                 position=top \
                 sticky=on \
                 padding_left=8 \
@@ -20,57 +21,130 @@ sketchybar --bar height=32 \
 # --- Defaults ---
 sketchybar --default icon.font="Hack Nerd Font:Bold:14.0" \
                      icon.color="$FG_COLOR" \
+                     icon.padding_left=8 \
+                     icon.padding_right=4 \
                      label.font="Hack Nerd Font:Regular:13.0" \
                      label.color="$FG_COLOR" \
-                     background.color="$ITEM_BG_COLOR" \
-                     background.corner_radius=5 \
-                     background.height=24 \
-                     padding_left=5 \
-                     padding_right=5 \
                      label.padding_left=4 \
-                     label.padding_right=4 \
-                     icon.padding_left=4 \
-                     icon.padding_right=4
+                     label.padding_right=8 \
+                     padding_left=4 \
+                     padding_right=4
 
-# --- Aerospace Workspace Change Event ---
+# --- Events ---
 sketchybar --add event aerospace_workspace_change
 
-# --- Workspaces (left) ---
+# ============================================================
+# LEFT SIDE
+# ============================================================
+
+# --- Workspaces ---
 for i in $(seq 1 10); do
   sketchybar --add item "space.$i" left \
              --subscribe "space.$i" aerospace_workspace_change \
              --set "space.$i" \
                icon="$i" \
-               icon.color="$FG_INACTIVE" \
+               icon.padding_left=10 \
+               icon.padding_right=10 \
                label.drawing=off \
+               background.color="$BRACKET_BG" \
+               background.corner_radius=5 \
+               background.height=24 \
+               background.drawing=off \
                script="$PLUGIN_DIR/aerospace.sh" \
-               click_script="aerospace workspace $i" \
-               background.drawing=off
+               click_script="aerospace workspace $i"
 done
 
-# Highlight current workspace on launch
 CURRENT="$(aerospace list-workspaces --focused 2>/dev/null || echo 1)"
 sketchybar --set "space.$CURRENT" background.drawing=on icon.color="$FG_COLOR"
 
-# --- Front App (left) ---
-sketchybar --add item front_app left \
-           --subscribe front_app front_app_switched \
-           --set front_app \
-             icon.drawing=off \
-             script="$PLUGIN_DIR/front_app.sh"
+# ============================================================
+# RIGHT SIDE
+# ============================================================
 
-# --- Clock (right) ---
-sketchybar --add item clock right \
-           --set clock \
+# --- Time ---
+sketchybar --add item time right \
+           --set time \
              icon="󰥔" \
-             update_freq=10 \
-             script="$PLUGIN_DIR/clock.sh"
+             update_freq=1 \
+             padding_left=4 \
+             padding_right=4 \
+             background.color="$BRACKET_BG" \
+             background.corner_radius=5 \
+             background.height=24 \
+             background.drawing=on \
+             script="$PLUGIN_DIR/time.sh"
 
-# --- Battery (right) ---
+# --- Spacer ---
+sketchybar --add item spacer.1 right --set spacer.1 width=8
+
+# --- Battery ---
 sketchybar --add item battery right \
+           --subscribe battery power_source_change \
            --set battery \
-             update_freq=120 \
+             update_freq=30 \
+             padding_left=4 \
+             padding_right=4 \
+             background.color="$BRACKET_BG" \
+             background.corner_radius=5 \
+             background.height=24 \
+             background.drawing=on \
              script="$PLUGIN_DIR/battery.sh"
+
+# --- Spacer ---
+sketchybar --add item spacer.2 right --set spacer.2 width=8
+
+# --- Volume ---
+sketchybar --add item volume right \
+           --subscribe volume volume_change \
+           --set volume \
+             update_freq=0 \
+             padding_left=4 \
+             padding_right=4 \
+             background.color="$BRACKET_BG" \
+             background.corner_radius=5 \
+             background.height=24 \
+             background.drawing=on \
+             script="$PLUGIN_DIR/volume.sh"
+
+# --- Spacer ---
+sketchybar --add item spacer.4 right --set spacer.4 width=8
+
+# --- CPU Graph ---
+sketchybar --add graph cpu right 40 \
+           --set cpu \
+             icon.drawing=off \
+             label.padding_left=6 \
+             label.padding_right=6 \
+             update_freq=3 \
+             graph.color="$ACCENT_COLOR" \
+             graph.fill_color="0x4089b4fa" \
+             graph.line_width=1 \
+             width=120 \
+             background.color="$BRACKET_BG" \
+             background.corner_radius=5 \
+             background.height=24 \
+             background.drawing=on \
+             script="$PLUGIN_DIR/cpu.sh"
+
+# --- Spacer ---
+sketchybar --add item spacer.3 right --set spacer.3 width=8
+
+# --- Memory Graph ---
+sketchybar --add graph memory right 40 \
+           --set memory \
+             icon.drawing=off \
+             label.padding_left=6 \
+             label.padding_right=6 \
+             update_freq=3 \
+             graph.color="$GREEN" \
+             graph.fill_color="0x40a6e3a1" \
+             graph.line_width=1 \
+             width=120 \
+             background.color="$BRACKET_BG" \
+             background.corner_radius=5 \
+             background.height=24 \
+             background.drawing=on \
+             script="$PLUGIN_DIR/memory.sh"
 
 # --- Init ---
 sketchybar --update


### PR DESCRIPTION
## Summary
- manage SketchyBar config through xdg.configFile
- add time, battery, volume, CPU, and memory widgets
- align AeroSpace top gap with the taller SketchyBar height

## Test
- nix flake check --no-build --all-systems