### PR TITLE
Build and launch LiveWallpaper with Nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -58,6 +58,24 @@
         "type": "github"
       }
     },
+    "liveWallpaperSrc": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780766901,
+        "narHash": "sha256-RQe7R0z63/JQsHMblC3A0G9CHk3a9t3+225jKP758/o=",
+        "ref": "release-build-without-previews",
+        "rev": "b52c85ce8bf826f57d073343aea25f59c29d9dd1",
+        "revCount": 20,
+        "type": "git",
+        "url": "ssh://git@github.com/TakabayaP/live-wallpaper.git"
+      },
+      "original": {
+        "ref": "release-build-without-previews",
+        "rev": "b52c85ce8bf826f57d073343aea25f59c29d9dd1",
+        "type": "git",
+        "url": "ssh://git@github.com/TakabayaP/live-wallpaper.git"
+      }
+    },
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
@@ -137,6 +155,7 @@
     "root": {
       "inputs": {
         "home-manager": "home-manager",
+        "liveWallpaperSrc": "liveWallpaperSrc",
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -16,13 +16,17 @@
       url = "github:nix-community/nixvim";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    liveWallpaperSrc = {
+      url = "git+ssh://git@github.com/TakabayaP/live-wallpaper.git?ref=release-build-without-previews&rev=b52c85ce8bf826f57d073343aea25f59c29d9dd1";
+      flake = false;
+    };
   };
 
-  outputs = { nixpkgs, home-manager, nix-darwin, nix-homebrew, nixvim, ... }:
+  outputs = { nixpkgs, home-manager, nix-darwin, nix-homebrew, nixvim, liveWallpaperSrc, ... }:
     let
       mkDarwinConfiguration = username: nix-darwin.lib.darwinSystem {
         system = "aarch64-darwin";
-        specialArgs = { inherit username; };
+        specialArgs = { inherit username liveWallpaperSrc; };
         modules = [
           ./hosts/macbook/system.nix
           nix-homebrew.darwinModules.nix-homebrew
@@ -37,7 +41,7 @@
           {
             home-manager.useGlobalPkgs = true;
             home-manager.useUserPackages = true;
-            home-manager.extraSpecialArgs = { inherit username; };
+            home-manager.extraSpecialArgs = { inherit username liveWallpaperSrc; };
             home-manager.users.${username} = {
               imports = [
                 nixvim.homeModules.nixvim

--- a/modules/darwin/live-wallpaper.nix
+++ b/modules/darwin/live-wallpaper.nix
@@ -1,11 +1,64 @@
-{ ... }:
+{ lib, pkgs, liveWallpaperSrc, ... }:
+let
+  liveWallpaper = pkgs.stdenvNoCC.mkDerivation {
+    pname = "live-wallpaper";
+    version = "1.1.0-b52c85c";
+
+    src = liveWallpaperSrc;
+
+    dontConfigure = true;
+    dontFixup = true;
+
+    __noChroot = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      export HOME="$TMPDIR"
+      export SYMROOT="$TMPDIR/build"
+
+      /usr/bin/xcrun xcodebuild \
+        -project LiveWallpaper.xcodeproj \
+        -scheme LiveWallpaper \
+        -configuration Release \
+        -derivedDataPath "$TMPDIR/DerivedData" \
+        SYMROOT="$SYMROOT" \
+        CODE_SIGNING_ALLOWED=NO \
+        CODE_SIGNING_REQUIRED=NO \
+        CODE_SIGN_IDENTITY= \
+        build
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out/Applications"
+      cp -R "$SYMROOT/Release/LiveWallpaper.app" "$out/Applications/"
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Set videos as the desktop wallpaper on macOS";
+      homepage = "https://github.com/TakabayaP/live-wallpaper";
+      license = lib.licenses.mit;
+      platforms = lib.platforms.darwin;
+    };
+  };
+in
 {
+  home.packages = [
+    liveWallpaper
+  ];
+
   launchd.agents.live-wallpaper = {
     enable = true;
     config = {
       Label = "com.baonguyen.LiveWallpaper.keepalive";
       ProgramArguments = [
-        "/Applications/LiveWallpaper.app/Contents/MacOS/LiveWallpaper"
+        "${liveWallpaper}/Applications/LiveWallpaper.app/Contents/MacOS/LiveWallpaper"
       ];
       RunAtLoad = true;
       KeepAlive = true;


### PR DESCRIPTION
## Summary
- Add the private live-wallpaper repo as a locked flake input
- Build LiveWallpaper.app from source with xcodebuild and signing disabled
- Launch the Nix store app through the existing Home Manager launchd agent

## Notes
- This depends on SSH access to git@github.com:TakabayaP/live-wallpaper.git when updating the flake input.
- The build uses Apple Xcode via /usr/bin/xcrun, so it is macOS/Xcode-dependent rather than a fully portable nixpkgs-style xcbuild package.
- On Apple Silicon, the binary is linker ad-hoc signed even with CODE_SIGNING_ALLOWED=NO; it is not Developer ID signed or notarized.

## Verification
- nix eval '.#darwinConfigurations.macbook-pro.config.home-manager.users."katsumi.kobayashi".launchd.agents.live-wallpaper.config.ProgramArguments'
- nix build '.#darwinConfigurations.macbook-pro.config.home-manager.users."katsumi.kobayashi".home.activationPackage'
- codesign -dv /nix/store/y4q9z8pr2y5d6vjqdv566kbn8zxvvyl2-live-wallpaper-1.1.0-b52c85c/Applications/LiveWallpaper.app