### PR TITLE
Fix Darwin service autostart

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ Command Line Tools に含まれる。
 
 5. 対象端末の構成を適用する。
 
+   LiveWallpaper のソースは private repository なので、先にログインユーザーの
+   SSH 鍵で Flake inputs を Nix store へ取得する。
+
+   ```sh
+   nix flake archive --no-update-lock-file .
+   ```
+
    MacBook Air:
 
    ```sh
@@ -66,6 +73,7 @@ Command Line Tools に含まれる。
 2回目以降は次のコマンドで適用する。
 
 ```sh
+nix flake archive --no-update-lock-file .
 sudo darwin-rebuild switch --flake .#macbook-air
 ```
 

--- a/flake.lock
+++ b/flake.lock
@@ -58,6 +58,24 @@
         "type": "github"
       }
     },
+    "liveWallpaperSrc": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780766901,
+        "narHash": "sha256-RQe7R0z63/JQsHMblC3A0G9CHk3a9t3+225jKP758/o=",
+        "ref": "release-build-without-previews",
+        "rev": "b52c85ce8bf826f57d073343aea25f59c29d9dd1",
+        "revCount": 20,
+        "type": "git",
+        "url": "ssh://git@github.com/TakabayaP/live-wallpaper.git"
+      },
+      "original": {
+        "ref": "release-build-without-previews",
+        "rev": "b52c85ce8bf826f57d073343aea25f59c29d9dd1",
+        "type": "git",
+        "url": "ssh://git@github.com/TakabayaP/live-wallpaper.git"
+      }
+    },
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
@@ -137,6 +155,7 @@
     "root": {
       "inputs": {
         "home-manager": "home-manager",
+        "liveWallpaperSrc": "liveWallpaperSrc",
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -16,13 +16,17 @@
       url = "github:nix-community/nixvim";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    liveWallpaperSrc = {
+      url = "git+ssh://git@github.com/TakabayaP/live-wallpaper.git?ref=release-build-without-previews&rev=b52c85ce8bf826f57d073343aea25f59c29d9dd1";
+      flake = false;
+    };
   };
 
-  outputs = { nixpkgs, home-manager, nix-darwin, nix-homebrew, nixvim, ... }:
+  outputs = { nixpkgs, home-manager, nix-darwin, nix-homebrew, nixvim, liveWallpaperSrc, ... }:
     let
       mkDarwinConfiguration = username: nix-darwin.lib.darwinSystem {
         system = "aarch64-darwin";
-        specialArgs = { inherit username; };
+        specialArgs = { inherit username liveWallpaperSrc; };
         modules = [
           ./hosts/macbook/system.nix
           nix-homebrew.darwinModules.nix-homebrew
@@ -37,7 +41,7 @@
           {
             home-manager.useGlobalPkgs = true;
             home-manager.useUserPackages = true;
-            home-manager.extraSpecialArgs = { inherit username; };
+            home-manager.extraSpecialArgs = { inherit username liveWallpaperSrc; };
             home-manager.users.${username} = {
               imports = [
                 nixvim.homeModules.nixvim

--- a/hosts/macbook/system.nix
+++ b/hosts/macbook/system.nix
@@ -22,7 +22,10 @@
       "orbstack"
     ];
     brews = [
-      "sketchybar"
+      {
+        name = "sketchybar";
+        start_service = true;
+      }
     ];
     onActivation = {
       autoUpdate = true;

--- a/modules/darwin/live-wallpaper.nix
+++ b/modules/darwin/live-wallpaper.nix
@@ -1,11 +1,64 @@
-{ ... }:
+{ lib, pkgs, liveWallpaperSrc, ... }:
+let
+  liveWallpaper = pkgs.stdenvNoCC.mkDerivation {
+    pname = "live-wallpaper";
+    version = "1.1.0-b52c85c";
+
+    src = liveWallpaperSrc;
+
+    dontConfigure = true;
+    dontFixup = true;
+
+    __noChroot = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      export HOME="$TMPDIR"
+      export SYMROOT="$TMPDIR/build"
+
+      /usr/bin/xcrun xcodebuild \
+        -project LiveWallpaper.xcodeproj \
+        -scheme LiveWallpaper \
+        -configuration Release \
+        -derivedDataPath "$TMPDIR/DerivedData" \
+        SYMROOT="$SYMROOT" \
+        CODE_SIGNING_ALLOWED=NO \
+        CODE_SIGNING_REQUIRED=NO \
+        CODE_SIGN_IDENTITY= \
+        build
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out/Applications"
+      cp -R "$SYMROOT/Release/LiveWallpaper.app" "$out/Applications/"
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Set videos as the desktop wallpaper on macOS";
+      homepage = "https://github.com/TakabayaP/live-wallpaper";
+      license = lib.licenses.mit;
+      platforms = lib.platforms.darwin;
+    };
+  };
+in
 {
+  home.packages = [
+    liveWallpaper
+  ];
+
   launchd.agents.live-wallpaper = {
     enable = true;
     config = {
       Label = "com.baonguyen.LiveWallpaper.keepalive";
       ProgramArguments = [
-        "/Applications/LiveWallpaper.app/Contents/MacOS/LiveWallpaper"
+        "${liveWallpaper}/Applications/LiveWallpaper.app/Contents/MacOS/LiveWallpaper"
       ];
       RunAtLoad = true;
       KeepAlive = true;


### PR DESCRIPTION
## Summary
- build LiveWallpaper from the pinned private repository source with Nix
- run LiveWallpaper from the Nix store through a Home Manager LaunchAgent
- start SketchyBar through Homebrew services at login
- document prefetching private Flake inputs before running darwin-rebuild

## Verification
- `sudo darwin-rebuild switch --flake .#macbook-air`
- confirmed `com.baonguyen.LiveWallpaper.keepalive` is running
- confirmed `homebrew.mxcl.sketchybar` is running