### PR TITLE
Use Fish in Neovim terminals

### DIFF
--- a/hosts/macbook/system.nix
+++ b/hosts/macbook/system.nix
@@ -22,6 +22,7 @@
       "orbstack"
     ];
     brews = [
+      "fish"
       {
         name = "sketchybar";
         start_service = true;

--- a/modules/common/neovim.nix
+++ b/modules/common/neovim.nix
@@ -20,6 +20,10 @@
       softtabstop = 4;
       termguicolors = true;
       mouse = "a";
+      shell =
+        if pkgs.stdenv.isDarwin
+        then "/opt/homebrew/bin/fish"
+        else "${pkgs.fish}/bin/fish";
     };
 
     # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- manage Fish through Homebrew on macOS
- configure NixVim to use Fish for `:terminal` and terminal plugins
- use the Nix Fish package path on non-Darwin systems

## Verification
- `sudo darwin-rebuild switch --flake .#macbook-air`
- `nvim --headless '+lua print(vim.o.shell)' +qa` returns `/opt/homebrew/bin/fish`