### PR TITLE
[codex] configure macOS input speed defaults

### DIFF
--- a/hosts/macbook/system.nix
+++ b/hosts/macbook/system.nix
@@ -1,4 +1,4 @@
-{ username, ... }:
+{ lib, username, ... }:
 {
   nixpkgs.hostPlatform = "aarch64-darwin";
 
@@ -44,7 +44,15 @@
 
   system.primaryUser = username;
 
-  system.defaults.NSGlobalDomain._HIHideMenuBar = true;
+  system.defaults = {
+    NSGlobalDomain = {
+      _HIHideMenuBar = true;
+      InitialKeyRepeat = 10;
+      KeyRepeat = 1;
+    };
+
+    CustomUserPreferences.".GlobalPreferences"."com.apple.mouse.scaling" = lib.mkForce (-1);
+  };
 
   security.pam.services.sudo_local = {
     touchIdAuth = true;

--- a/modules/darwin/aerospace.nix
+++ b/modules/darwin/aerospace.nix
@@ -13,6 +13,7 @@ let
 
     gaps = {
       outer.top = [
+        { monitor = { "BenQ GW2480" = 38; }; }
         { monitor = { "BenQ GW2480.*1" = 38; }; }
         { monitor = { "BenQ GW2480.*2" = 38; }; }
         { monitor = { "LG HDR 4K" = 38; }; }


### PR DESCRIPTION
## Summary

- Set macOS key repeat defaults to the fastest values in the shared macbook system module.
- Force `.GlobalPreferences` `com.apple.mouse.scaling` to `-1` via nix-darwin custom user preferences.
- Include the existing AeroSpace BenQ GW2480 gap override change in the same PR.

## Validation

- `nix eval .#darwinConfigurations.macbook-air.config.system.defaults.NSGlobalDomain.KeyRepeat`
- `nix eval --json .#darwinConfigurations.macbook-air.config.system.defaults.CustomUserPreferences`
- `nix build .#darwinConfigurations.macbook-air.system --dry-run`
- `nix build .#darwinConfigurations.macbook-pro.system --dry-run`
- `git diff --check`