### PR TITLE
fix: gitsigns diffthis をトグル化して :q 後のバッファ残留を防止

### DIFF
--- a/modules/common/neovim.nix
+++ b/modules/common/neovim.nix
@@ -409,7 +409,7 @@
               local buf = vim.api.nvim_win_get_buf(win)
               local name = vim.api.nvim_buf_get_name(buf)
               if name:match("^gitsigns://") then
-                vim.api.nvim_win_close(win, true)
+                vim.api.nvim_buf_delete(buf, { force = true })
                 vim.cmd("diffoff")
                 return
               end

--- a/modules/common/neovim.nix
+++ b/modules/common/neovim.nix
@@ -402,7 +402,22 @@
       { mode = "n"; key = "-"; action.__raw = "function() Snacks.explorer.open() end"; options.desc = "Explorer (toggle)"; }
 
       # Git差分・blame
-      { mode = "n"; key = "<leader>gd"; action = "<cmd>Gitsigns diffthis<cr>"; options = { desc = "Git Diff"; silent = true; }; }
+      { mode = "n"; key = "<leader>gd"; options = { desc = "Git Diff (toggle)"; silent = true; };
+        action.__raw = ''
+          function()
+            for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+              local buf = vim.api.nvim_win_get_buf(win)
+              local name = vim.api.nvim_buf_get_name(buf)
+              if name:match("^gitsigns://") then
+                vim.api.nvim_win_close(win, true)
+                vim.cmd("diffoff")
+                return
+              end
+            end
+            require("gitsigns").diffthis()
+          end
+        '';
+      }
       { mode = "n"; key = "<leader>gb"; action = "<cmd>Gitsigns blame_line<cr>"; options = { desc = "Git Blame"; silent = true; }; }
       { mode = "n"; key = "<leader>gp"; action = "<cmd>Gitsigns preview_hunk<cr>"; options = { desc = "Git Hunk Preview"; silent = true; }; }
       { mode = "n"; key = "]c"; action = "<cmd>Gitsigns next_hunk<cr>"; options = { desc = "次の変更箇所"; silent = true; }; }


### PR DESCRIPTION
## Summary

- `<leader>gd` (`Gitsigns diffthis`) を Lua 関数によるトグル動作に変更
- diff が開いている状態で再度 `<leader>gd` を押すと、gitsigns バッファのウィンドウを閉じて `diffoff` する
- これにより `:q` で `gitsigns://` バッファが残る問題を回避できる

## Background

`Gitsigns diffthis` 実行後に `:q` すると、元のファイルバッファが閉じられ gitsigns の内部バッファ（`gitsigns:///...` URI）だけが残ってしまう問題があった。

## Test plan

- [ ] `home-manager switch` で設定反映
- [ ] git 管理下のファイルで `<leader>gd` → diff が表示される
- [ ] diff 表示中に再度 `<leader>gd` → 元のバッファに正しく戻る

🤖 Generated with [Claude Code](https://claude.ai/code)