### PR TITLE
[codex] Add Codex Desktop Linux home package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,6 +17,27 @@
         "type": "github"
       }
     },
+    "codex-desktop-linux": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782545641,
+        "narHash": "sha256-6gWxXDwxsLz9mXWyLAbTT2+fI9AE16+6kvVWvs0h1EI=",
+        "owner": "ilysenko",
+        "repo": "codex-desktop-linux",
+        "rev": "61c72b42dea17d4cfbfef0234d548e962fb0eaa4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ilysenko",
+        "repo": "codex-desktop-linux",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -35,6 +56,24 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -136,7 +175,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1780421606,
@@ -154,6 +193,7 @@
     },
     "root": {
       "inputs": {
+        "codex-desktop-linux": "codex-desktop-linux",
         "home-manager": "home-manager",
         "liveWallpaperSrc": "liveWallpaperSrc",
         "nix-darwin": "nix-darwin",
@@ -163,6 +203,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1774449309,
         "narHash": "sha256-brhZ8DmuGtzkCYHJg4HEd602amKm89Y9ytsFZ5uWD1w=",

--- a/flake.nix
+++ b/flake.nix
@@ -16,13 +16,17 @@
       url = "github:nix-community/nixvim";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    codex-desktop-linux = {
+      url = "github:ilysenko/codex-desktop-linux";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     liveWallpaperSrc = {
       url = "git+ssh://git@github.com/TakabayaP/live-wallpaper.git?ref=release-build-without-previews&rev=b52c85ce8bf826f57d073343aea25f59c29d9dd1";
       flake = false;
     };
   };
 
-  outputs = { nixpkgs, home-manager, nix-darwin, nix-homebrew, nixvim, liveWallpaperSrc, ... }:
+  outputs = { nixpkgs, home-manager, nix-darwin, nix-homebrew, nixvim, codex-desktop-linux, liveWallpaperSrc, ... }:
     let
       mkDarwinConfiguration = username: nix-darwin.lib.darwinSystem {
         system = "aarch64-darwin";
@@ -53,24 +57,32 @@
           }
         ];
       };
+      mkLinuxHomeConfiguration = home-manager.lib.homeManagerConfiguration {
+        pkgs = import nixpkgs { system = "x86_64-linux"; };
+        extraSpecialArgs = { username = "takabaya"; };
+        modules = [
+          nixvim.homeModules.nixvim
+          codex-desktop-linux.homeManagerModules.default
+          ./hosts/takabayap-H1-arch/default.nix
+          ({ pkgs, ... }: {
+            home.stateVersion = "24.11";
+            programs.home-manager.enable = true;
+            programs.codexDesktopLinux = {
+              enable = true;
+              cliPackage = pkgs.codex;
+            };
+          })
+        ];
+      };
     in {
     darwinConfigurations = {
       macbook-pro = mkDarwinConfiguration "katsumi.kobayashi";
       macbook-air = mkDarwinConfiguration "katsumikobayashi";
     };
 
-    homeConfigurations."takabaya@takabayap-H1-arch-i3" =
-      home-manager.lib.homeManagerConfiguration {
-        pkgs = import nixpkgs { system = "x86_64-linux"; };
-        extraSpecialArgs = { username = "takabaya"; };
-        modules = [
-          nixvim.homeModules.nixvim
-          ./hosts/takabayap-H1-arch/default.nix
-          {
-            home.stateVersion = "24.11";
-            programs.home-manager.enable = true;
-          }
-        ];
-      };
+    homeConfigurations = {
+      "takabaya@takabayap-H1-arch" = mkLinuxHomeConfiguration;
+      "takabaya@takabayap-H1-arch-i3" = mkLinuxHomeConfiguration;
+    };
   };
 }


### PR DESCRIPTION
## Summary

- Add the upstream `ilysenko/codex-desktop-linux` flake input.
- Import its Home Manager module for the Linux home configuration.
- Enable Codex Desktop on the Arch Home Manager profiles and point the launcher at the Nixpkgs `codex` CLI package.

## Validation

- `nix eval --json .#homeConfigurations."takabaya@takabayap-H1-arch".activationPackage.drvPath`
- `home-manager switch --flake .#takabaya@takabayap-H1-arch`
